### PR TITLE
Zas ported to golang.org/x/net/html & goquery

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -21,7 +21,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/bevik/etree"
+	"github.com/beevik/etree"
 	"github.com/melvinmt/gt"
 	markdown "github.com/russross/blackfriday"
 	yaml "gopkg.in/yaml.v2"


### PR DESCRIPTION
With this change, Zas doesn't have any native dependency and its code is a bit shorter thanks to goquery.